### PR TITLE
Add additional console output for post refresh console command

### DIFF
--- a/src/console/controllers/PostsController.php
+++ b/src/console/controllers/PostsController.php
@@ -55,13 +55,19 @@ class PostsController extends Controller
 
         $source = SocialFeeds::$plugin->getSources()->getSourceByHandle($this->source, true, true);
 
+        if (!$source) {
+            $this->stderr('Invalid source handle specified.' . PHP_EOL, Console::FG_RED);
+
+            return ExitCode::UNSPECIFIED_ERROR;
+        }
+
         if ($this->limit) {
             SocialFeeds::$plugin->getSettings()->postsLimit = $this->limit;
         }
 
-        if ($source) {
-            SocialFeeds::$plugin->getPosts()->refreshPosts($source, $this);
-        }
+        SocialFeeds::$plugin->getPosts()->refreshPosts($source, $this);
+
+        $this->stdout("Source handle: $this->source was refreshed successfully!" . PHP_EOL, Console::FG_GREEN);
 
         return ExitCode::OK;
     }

--- a/src/console/controllers/PostsController.php
+++ b/src/console/controllers/PostsController.php
@@ -1,12 +1,14 @@
 <?php
 namespace verbb\socialfeeds\console\controllers;
 
+use Throwable;
 use verbb\socialfeeds\SocialFeeds;
 
 use craft\console\Controller;
 use craft\helpers\Console;
 
 use yii\console\ExitCode;
+use yii\helpers\BaseConsole;
 
 /**
  * Manages Social Feeds Posts.
@@ -68,6 +70,28 @@ class PostsController extends Controller
         SocialFeeds::$plugin->getPosts()->refreshPosts($source, $this);
 
         $this->stdout("Source handle: $this->source was refreshed successfully!" . PHP_EOL, Console::FG_GREEN);
+
+        return ExitCode::OK;
+    }
+
+    /**
+     * Refresh all enabled sources
+     *
+     * @throws Throwable
+     * @return int
+     */
+    public function actionRefreshEnabledSources(): int
+    {
+        $sources = SocialFeeds::$plugin->getSources()->getAllEnabledSources();
+
+        foreach ($sources as $source) {
+
+            $this->stdout("Refreshing posts for source: $source->handle" . PHP_EOL, Console::FG_YELLOW);
+
+            SocialFeeds::$plugin->getPosts()->refreshPosts($source, $this);
+        }
+
+        $this->stdout('All caches for sources cleared successfully' . PHP_EOL, Console::FG_GREEN);
 
         return ExitCode::OK;
     }


### PR DESCRIPTION
The refresh post console command currently does not output information besides when the --source parameter is blank.

This updates the console command to return an error if an invalid source handle is specified and also if the refresh command was successful.